### PR TITLE
feature/EODHP-573-wire-up-login-page-on-web-presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.1.18 (Unreleased)
+
+- Updated db-migrate job for web presence 0.1.17
+- Refactored opal into separate, optional deployment
+- Fixed bug when values files has no extraEnvs or extraEnvFroms
+- Refactored web.images to be a structure
+
 ## v0.1.17 (24-07-2024)
 
 - Fix sidecar for authZ integration
@@ -24,12 +31,12 @@
 
 - Add optional web presence service account
 - Add USE_S3 environment variable
-- Update to use v0.1.11 docker image 
+- Update to use v0.1.11 docker image
 - Add environment variables for identification
 
 ## v0.1.10 (04-06-2024)
 
-- Update to use v0.1.10 docker image 
+- Update to use v0.1.10 docker image
 - Add environment variables for caching
 
 ## 0.1.9 (14-05-2024)
@@ -39,7 +46,7 @@
 
 ## v0.1.8 (26-04-2024)
 
-- Update to use v0.1.8 docker image 
+- Update to use v0.1.8 docker image
 
 ## v0.1.7 (15-04-2024)
 
@@ -49,11 +56,11 @@
 
 ## v0.1.6 (02-04-2024)
 
-- Update to use v0.1.6 docker image 
+- Update to use v0.1.6 docker image
 
 ## v0.1.5 (02-04-2024)
 
-- Update to use v0.1.5 docker image 
+- Update to use v0.1.5 docker image
 
 ## v0.1.4 (20-03-2024)
 
@@ -62,7 +69,7 @@
 ## v0.1.3 (19-03-2024)
 
 - Updated to use v0.1.4 docker image
-  
+
 ## v0.1.2 (05-03-2024)
 
 - Updated to use v0.1.2 docker image
@@ -71,7 +78,6 @@
 
 - Updated to use v0.1.1 docker image
 - Removed unused PVC
-
 
 ## v0.1.0 (16-02-2024)
 

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.18-rc4
+version: 0.1.18-rc5
 appVersion: "0.1.17"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.17
+version: 0.1.18-rc1
 appVersion: "0.1.17"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.18-rc2
+version: 0.1.18-rc3
 appVersion: "0.1.17"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.18-rc3
+version: 0.1.18-rc4
 appVersion: "0.1.17"

--- a/eodhp-web-presence/Chart.yaml
+++ b/eodhp-web-presence/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eodhp-web-presence
 description: The EODHP Web Presence
 type: application
-version: 0.1.18-rc1
+version: 0.1.18-rc2
 appVersion: "0.1.17"

--- a/eodhp-web-presence/templates/migrate-job.yaml
+++ b/eodhp-web-presence/templates/migrate-job.yaml
@@ -10,8 +10,8 @@ spec:
     spec:
       containers:
       - name: db-migrate
-        image: {{ .Values.web.image }}
-        imagePullPolicy: Always
+        image: "{{ .Values.web.image.name }}:{{ .Values.web.image.tag }}"
+        imagePullPolicy: {{ .Values.web.image.pullPolicy }}
         entrypoint: [manage]
         command: [migrate]
         {{- if or (and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret)) (.Values.web.extraEnvs) }}

--- a/eodhp-web-presence/templates/migrate-job.yaml
+++ b/eodhp-web-presence/templates/migrate-job.yaml
@@ -12,10 +12,8 @@ spec:
       - name: db-migrate
         image: {{ .Values.web.image }}
         imagePullPolicy: Always
-        entrypoint: manage
-        command: migrate
-        envFrom:
-            {{- toYaml .Values.web.extraEnvFrom | nindent 12 }}
+        entrypoint: [manage]
+        command: [migrate]
         env:
           {{- if and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret) }}
           - name: SQL_PASSWORD
@@ -24,6 +22,9 @@ spec:
                 name: {{ .Values.web.database.existingSecret }}
                 key:  {{ .Values.web.database.secretKeys.sqlPasswordKey }}
           {{- end }}
+          {{- toYaml .Values.web.extraEnvs | nindent 10 }}
+        envFrom:
+          {{- toYaml .Values.web.extraEnvFrom | nindent 10 }}
       restartPolicy: OnFailure
   backoffLimit: 10
 {{ end }}

--- a/eodhp-web-presence/templates/migrate-job.yaml
+++ b/eodhp-web-presence/templates/migrate-job.yaml
@@ -1,7 +1,10 @@
+{{ if .Values.web.migrateJob.create }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: db-migrate
+  annotations:
+    {{- toYaml .Values.web.migrateJob.annotations | nindent 4 }}
 spec:
   template:
     spec:
@@ -9,7 +12,8 @@ spec:
       - name: db-migrate
         image: {{ .Values.web.image }}
         imagePullPolicy: Always
-        command: ["sh", "-c", "python manage.py migrate"]
+        entrypoint: manage
+        command: migrate
         envFrom:
             {{- toYaml .Values.web.extraEnvFrom | nindent 12 }}
         env:
@@ -22,3 +26,4 @@ spec:
           {{- end }}
       restartPolicy: OnFailure
   backoffLimit: 10
+{{ end }}

--- a/eodhp-web-presence/templates/migrate-job.yaml
+++ b/eodhp-web-presence/templates/migrate-job.yaml
@@ -12,8 +12,8 @@ spec:
       - name: db-migrate
         image: "{{ .Values.web.image.name }}:{{ .Values.web.image.tag }}"
         imagePullPolicy: {{ .Values.web.image.pullPolicy }}
-        entrypoint: [manage]
-        command: [migrate]
+        command: [manage]
+        args: [migrate]
         {{- if or (and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret)) (.Values.web.extraEnvs) }}
         env:
           {{- if and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret) }}

--- a/eodhp-web-presence/templates/migrate-job.yaml
+++ b/eodhp-web-presence/templates/migrate-job.yaml
@@ -14,6 +14,7 @@ spec:
         imagePullPolicy: Always
         entrypoint: [manage]
         command: [migrate]
+        {{- if or (and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret)) (.Values.web.extraEnvs) }}
         env:
           {{- if and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret) }}
           - name: SQL_PASSWORD
@@ -22,9 +23,14 @@ spec:
                 name: {{ .Values.web.database.existingSecret }}
                 key:  {{ .Values.web.database.secretKeys.sqlPasswordKey }}
           {{- end }}
+          {{- if .Values.web.extraEnvs }}
           {{- toYaml .Values.web.extraEnvs | nindent 10 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.web.extraEnvFrom }}
         envFrom:
           {{- toYaml .Values.web.extraEnvFrom | nindent 10 }}
+        {{- end }}
       restartPolicy: OnFailure
   backoffLimit: 10
 {{ end }}

--- a/eodhp-web-presence/templates/migrate-job.yaml
+++ b/eodhp-web-presence/templates/migrate-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: db-migrate
-        image: "{{ .Values.web.image.name }}:{{ .Values.web.image.tag }}"
+        image: "{{ .Values.web.image.name }}:{{ default "latest" .Values.web.image.tag }}"
         imagePullPolicy: {{ .Values.web.image.pullPolicy }}
         command: [manage]
         args: [migrate]

--- a/eodhp-web-presence/templates/opal-client-deploy.yaml
+++ b/eodhp-web-presence/templates/opal-client-deploy.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opal-client
+spec:
+  replicas: {{.Values.opal.replicas}}
+  selector:
+    matchLabels:
+      app: opal-client
+  template:
+    metadata:
+      labels:
+        app: opal-client
+    spec:
+      serviceAccountName: {{.Values.web.serviceAccount.name}}
+      containers:
+        - name: web-presence-opal
+          image: "{{ .Values.opal.image.name }}:{{ .Values.opal.image.tag }}"
+          imagePullPolicy: {{.Values.opal.image.pullPolicy}}
+          ports:
+            - name: http
+              containerPort: 7000
+              protocol: TCP
+            - name: opa
+              containerPort: 8181
+              protocol: TCP
+          env:
+            - name: UVICORN_NUM_WORKERS
+              value: "1"
+            - name: OPAL_LOG_LEVEL
+              value: {{.Values.opal.env.log_levels}}
+            - name: OPAL_SERVER_URL
+              value: {{.Values.opal.env.server_url}}

--- a/eodhp-web-presence/templates/opal-client-deploy.yaml
+++ b/eodhp-web-presence/templates/opal-client-deploy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.opal.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,3 +32,4 @@ spec:
               value: {{.Values.opal.env.log_levels}}
             - name: OPAL_SERVER_URL
               value: {{.Values.opal.env.server_url}}
+{{- end }}

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: eodhp-web-presence
 spec:
-  replicas: 1
+  replicas: {{ .Values.web.replicas }}
   selector:
     matchLabels:
       app: eodhp-web-presence
@@ -15,8 +15,8 @@ spec:
       serviceAccountName: {{ .Values.web.serviceAccount.name }}
       containers:
         - name: eodhp-web-presence
-          image: {{ .Values.web.image }}
-          imagePullPolicy: Always
+          image: "{{ .Values.web.image }}:{{ .Values.web.tag }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           ports:
             - containerPort: 8000
           {{- if or (and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret)) (.Values.web.extraEnv) (.Values.web.djangoSecret.existingSecret) }}

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -19,8 +19,6 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
-          envFrom:
-            {{- toYaml .Values.web.extraEnvFrom | nindent 12 }}
           env:
             {{- if and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret) }}
             - name: SQL_PASSWORD
@@ -29,13 +27,16 @@ spec:
                   name: {{ .Values.web.database.existingSecret }}
                   key:  {{ .Values.web.database.secretKeys.sqlPasswordKey }}
             {{- end }}
+            {{- if .Values.web.djangoSecret.existingSecret }}
             - name: SECRET_KEY
-              {{- if .Values.web.djangoSecret.existingSecret }}
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.web.djangoSecret.existingSecret }}
                   key: {{ .Values.web.djangoSecret.existingSecretKey }}
-              {{- end }}
+            {{- end }}
+            {{- toYaml .Values.web.extraEnv | nindent 12 }}
+          envFrom:
+            {{- toYaml .Values.web.extraEnvFrom | nindent 12 }}
         - name: web-presence-opal-sidecar
           image: {{ .Values.opalSidecar.image }}
           imagePullPolicy: Always

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: {{ .Values.web.serviceAccount.name }}
       containers:
         - name: eodhp-web-presence
-          image: "{{ .Values.web.image.name }}:{{ .Values.web.tag }}"
+          image: "{{ .Values.web.image.name }}:{{ .Values.web.image.tag | default latest }}"
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           ports:
             - containerPort: 8000

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -43,20 +43,3 @@ spec:
           envFrom:
             {{- toYaml .Values.web.extraEnvFrom | nindent 12 }}
           {{- end }}
-        - name: web-presence-opal-sidecar
-          image: {{ .Values.opalSidecar.image }}
-          imagePullPolicy: Always
-          ports:
-            - name: http
-              containerPort: 7000
-              protocol: TCP
-            - name: opa
-              containerPort: 8181
-              protocol: TCP
-          env:
-            - name: UVICORN_NUM_WORKERS
-              value: "1"
-            - name: OPAL_LOG_LEVEL
-              value: {{ .Values.opalSidecar.env.log_levels }}
-            - name: OPAL_SERVER_URL
-              value: {{ .Values.opalSidecar.env.server_url }}

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: {{ .Values.web.serviceAccount.name }}
       containers:
         - name: eodhp-web-presence
-          image: "{{ .Values.web.image }}:{{ .Values.web.tag }}"
+          image: "{{ .Values.web.image.name }}:{{ .Values.web.tag }}"
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           ports:
             - containerPort: 8000

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: {{ .Values.web.serviceAccount.name }}
       containers:
         - name: eodhp-web-presence
-          image: "{{ .Values.web.image.name }}:{{ .Values.web.image.tag | default latest }}"
+          image: "{{ .Values.web.image.name }}:{{ default "latest" .Values.web.image.tag }}"
           imagePullPolicy: {{ .Values.web.image.pullPolicy }}
           ports:
             - containerPort: 8000

--- a/eodhp-web-presence/templates/web-presence-deploy.yaml
+++ b/eodhp-web-presence/templates/web-presence-deploy.yaml
@@ -19,6 +19,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8000
+          {{- if or (and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret)) (.Values.web.extraEnv) (.Values.web.djangoSecret.existingSecret) }}
           env:
             {{- if and (.Values.web.database.secretKeys.sqlPasswordKey) (.Values.web.database.existingSecret) }}
             - name: SQL_PASSWORD
@@ -34,9 +35,14 @@ spec:
                   name: {{ .Values.web.djangoSecret.existingSecret }}
                   key: {{ .Values.web.djangoSecret.existingSecretKey }}
             {{- end }}
+            {{- if .Values.web.extraEnv }}
             {{- toYaml .Values.web.extraEnv | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.web.extraEnvFrom }}
           envFrom:
             {{- toYaml .Values.web.extraEnvFrom | nindent 12 }}
+          {{- end }}
         - name: web-presence-opal-sidecar
           image: {{ .Values.opalSidecar.image }}
           imagePullPolicy: Always

--- a/eodhp-web-presence/values.yaml
+++ b/eodhp-web-presence/values.yaml
@@ -2,69 +2,67 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 web:
   image: public.ecr.aws/n1b3o1k2/eodhp-web-presence:0.1.12
 
   extraEnvs:
-    - name: MY_EXTRA_ENV
-      value: MY_VALUE
-    - name: SQL_PORT
-      value: 5432
-    - name: SQL_ENGINE
-      value: django.db.backends.postgresql_psycopg2
-    - name: APP_URL
-      value: dev.eodatahub.org.uk
-    - name: EOX_VIEWSERVER_URL
-      value: https://my.eoxviewserver.org.uk
-    - name: RESOURCE_CATALOGUE_URL
-      value: https://my.resourcecatalogue.org.uk
-    - name: RESOURCE_CATALOGUE_VERSION
-      value: main
-    - name: CATALOGUE_DATA_URL
-      value: https://my.resourcecataloguedata.org.uk/api/
-    - name: NOTEBOOKS_URL
-      value: https://my.notebooks.org.uk/
-    - name: ALLOWED_HOSTS
-      value: host.eodatahub.org.uk
-    - name: BASE_URL
-      value: https://www.eodatahub.org.uk
-    - name: PAGE_CACHE_LENGTH
-      value: 300
-    - name: STATIC_FILE_CACHE_LENGTH
-      value: 3600
-    - name: IS_PROD
-      value: 0
-    - name: USE_S3
-      value: True
-    - name: ENV_NAME
-      value: dev
-    # Can alternately be configured using existing secret and key.
-    # Defining env var SQL_PASSWORD directly and existing secret/key are mutually exclusive
-    - name: SQL_PASSWORD
-      value: password
-    - name: SQL_HOST
-      value: host
-    - name: SQL_USER
-      value: user
-    - name: SQL_DATABASE
-      value: db
-    - name: ENABLE_OPA
-      value: 1
-    - name: OPAL_SERVER
-      value: server.opal:1234
-    - name: OPAL_PATH
-      value: /v1/path
-  extraEnvFrom: {}
-#    - configMapRef:
-#        name: web-presence-envs-config-map
-#    - secretRef:
-#        name: web-presence-envs
+    []
+    # - name: SQL_PORT
+    #   value: 5432
+    # - name: SQL_ENGINE
+    #   value: django.db.backends.postgresql_psycopg2
+    # - name: APP_URL
+    #   value: dev.eodatahub.org.uk
+    # - name: EOX_VIEWSERVER_URL
+    #   value: https://my.eoxviewserver.org.uk
+    # - name: RESOURCE_CATALOGUE_URL
+    #   value: https://my.resourcecatalogue.org.uk
+    # - name: RESOURCE_CATALOGUE_VERSION
+    #   value: main
+    # - name: CATALOGUE_DATA_URL
+    #   value: https://my.resourcecataloguedata.org.uk/api/
+    # - name: NOTEBOOKS_URL
+    #   value: https://my.notebooks.org.uk/
+    # - name: ALLOWED_HOSTS
+    #   value: host.eodatahub.org.uk
+    # - name: BASE_URL
+    #   value: https://www.eodatahub.org.uk
+    # - name: PAGE_CACHE_LENGTH
+    #   value: 300
+    # - name: STATIC_FILE_CACHE_LENGTH
+    #   value: 3600
+    # - name: IS_PROD
+    #   value: 0
+    # - name: USE_S3
+    #   value: True
+    # - name: ENV_NAME
+    #   value: dev
+    # # Can alternately be configured using existing secret and key.
+    # # Defining env var SQL_PASSWORD directly and existing secret/key are mutually exclusive
+    # - name: SQL_PASSWORD
+    #   value: password
+    # - name: SQL_HOST
+    #   value: host
+    # - name: SQL_USER
+    #   value: user
+    # - name: SQL_DATABASE
+    #   value: db
+    # - name: ENABLE_OPA
+    #   value: 1
+    # - name: OPAL_SERVER
+    #   value: server.opal:1234
+    # - name: OPAL_PATH
+    #   value: /v1/path
+  extraEnvFrom: []
+  #    - configMapRef:
+  #        name: web-presence-envs-config-map
+  #    - secretRef:
+  #        name: web-presence-envs
 
   djangoSecret:
     value: insecure-secret
-    existingSecret: ""
-    existingSecretKey: ""
+    existingSecret: null
+    existingSecretKey: null
 
   migrateJob:
     create: true
@@ -76,9 +74,9 @@ web:
     create: true
 
   database:
-    existingSecret: ""
+    existingSecret: null
     secretKeys:
-      sqlPasswordKey: ""
+      sqlPasswordKey: null
 
   storage_class: standard
 

--- a/eodhp-web-presence/values.yaml
+++ b/eodhp-web-presence/values.yaml
@@ -92,9 +92,13 @@ web:
     annotations:
       eks.amazonaws.com/role-arn: "arn:aws:iam::312280911266:role/eodhp-dev-web-presence-role"
 
-opalSidecar:
-  enabled: true
-  image: permitio/opal-client
+opal:
+  enabled: false
+  image:
+    name: permitio/opal-client
+    tag: 0.7.6
+    pullPolicy: IfNotPresent
+  replicas: 1
   env:
-    log_levels: DEBUG
-    server_url: http://opal-server.opal:7002
+    log_levels: WARNING
+    server_url: http://opal-server:7002

--- a/eodhp-web-presence/values.yaml
+++ b/eodhp-web-presence/values.yaml
@@ -66,6 +66,10 @@ web:
     existingSecret: ""
     existingSecretKey: ""
 
+  migrateJob:
+    create: true
+    annotations: {}
+
   ingress:
     host: eodhp-web-presence.test.com
     className: nginx

--- a/eodhp-web-presence/values.yaml
+++ b/eodhp-web-presence/values.yaml
@@ -3,8 +3,11 @@
 # Declare variables to be passed into your templates.
 
 web:
-  image: public.ecr.aws/n1b3o1k2/eodhp-web-presence:0.1.12
-
+  image:
+    name: public.ecr.aws/n1b3o1k2/eodhp-web-presence
+    tag: 0.1.12
+    pullPolicy: IfNotPresent
+  replicas: 1
   extraEnvs:
     []
     # - name: SQL_PORT

--- a/eodhp-web-presence/values.yaml
+++ b/eodhp-web-presence/values.yaml
@@ -5,7 +5,7 @@
 web:
   image:
     name: public.ecr.aws/n1b3o1k2/eodhp-web-presence
-    tag: 0.1.12
+    tag: 0.1.17
     pullPolicy: IfNotPresent
   replicas: 1
   extraEnvs:


### PR DESCRIPTION
Mainly this was to update the db-migrate job to use new docker run --entrypoint manage <name> migrate command, but i tidied a few other things up while i was here.

Opal was deployed in same deployment as web presence, it should have been deployed separately as an optional deployment
Some configurations of values file were not working, usually if no env vars were present in values files. Added conditional logic to protect against it
commented out default env vars to leave them as documentation for other users
reformatted image values into a structure instead of a flat name
removed default of Always for image pull policy (this is something we only want to turn on in dev)